### PR TITLE
Подготовка к деплою на Timeweb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:20-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps
-RUN apk add --no-cache libc6-compat postgresql-client
+RUN apk add --no-cache libc6-compat
 
 WORKDIR /app
 
@@ -38,15 +38,11 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 
-# Copy database schemas for migrations
-COPY --from=builder /app/lib/database ./lib/database
-COPY --from=builder /app/scripts ./scripts
-
 USER nextjs
 
-EXPOSE 8080
+EXPOSE 3000
 
-ENV PORT 8080
+ENV PORT 3000
 ENV HOSTNAME "0.0.0.0"
 
 CMD ["node", "server.js"]

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Standalone output для запуска в Docker/Timeweb App
+  output: 'standalone',
+
   // Включить React Strict Mode
   reactStrictMode: true,
   


### PR DESCRIPTION
Prepare Next.js project for standalone Docker deployment on Timeweb Cloud App Platform by enabling standalone output and optimizing the Dockerfile.

The `output: 'standalone'` configuration in `next.config.js` is essential for Next.js to generate a self-contained output directory (`.next/standalone`) that includes all necessary files and dependencies to run the application as a standalone server, which is ideal for Docker environments. The Dockerfile was updated to leverage this output, remove unnecessary client tools and scripts from the final image, and standardize the exposed port to `3000`.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-64b6e6c2-96e9-4fe2-acf7-4a1a60e9a441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-64b6e6c2-96e9-4fe2-acf7-4a1a60e9a441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

